### PR TITLE
Fixed: wrong 'needs' condition in the publish job

### DIFF
--- a/.github/workflows/release-specific.yml
+++ b/.github/workflows/release-specific.yml
@@ -8,7 +8,6 @@ on:
 jobs:
 
   publish:
-    needs: build
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fixed: wrong `needs` condition in the publish job