### PR TITLE
just-sysprocess v0.3.0

### DIFF
--- a/changelogs/0.3.0.md
+++ b/changelogs/0.3.0.md
@@ -1,0 +1,4 @@
+## [0.3.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone3%22) - 2020-11-14
+
+## Done
+* Support Scala 3.0.0-M1 (#18)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object ProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.2.0"
+  val ProjectVersion: String = "0.3.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.13" | "2.12" | "2.11" =>


### PR DESCRIPTION
# just-sysprocess v0.3.0
## [0.3.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone3%22) - 2020-11-14

## Done
* Support Scala 3.0.0-M1 (#18)
