### PR TITLE
just-sysprocess v0.3.0 - Removed: supported Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val removeDottyIncompatible: ModuleID => Boolean =
       m.name == "mdoc"
 
 val CrossScalaVersions: Seq[String] = Seq(
-  "2.11.12", "2.12.12", "2.13.3", "0.26.0", "0.27.0", ProjectScalaVersion
+  "2.11.12", "2.12.12", "2.13.3", ProjectScalaVersion
 ).distinct
 val IncludeTest: String = "compile->compile;test->test"
 


### PR DESCRIPTION
# just-sysprocess v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone2%22) - 2020-08-15

## Done
* Support Dotty (#12)
