### PR TITLE
just-sysprocess v0.4.0

### DIFF
--- a/.github/workflows/release-specific.yml
+++ b/.github/workflows/release-specific.yml
@@ -19,6 +19,7 @@ jobs:
           - { name: 'Scala', version: "2.13.4",  binary-version: "2.13", java-version: "11" }
           - { name: 'Dotty', version: "3.0.0-M1", binary-version: "3.0.0-M1", java-version: "11" }
           - { name: 'Dotty', version: "3.0.0-M2", binary-version: "3.0.0-M2", java-version: "11" }
+          - { name: 'Dotty', version: "3.0.0-M3", binary-version: "3.0.0-M3", java-version: "11" }
 
     steps:
       - uses: actions/checkout@v2

--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,5 @@
+## [0.4.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone4%22) - 2021-01-08
+
+## Done
+* Support Scala `3.0.0-M2` (#24)
+* Support Scala `3.0.0-M3` (#29)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object ProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.3.0"
+  val ProjectVersion: String = "0.4.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.13" | "2.12" | "2.11" =>


### PR DESCRIPTION
# just-sysprocess v0.4.0
## [0.4.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone4%22) - 2021-01-08

## Done
* Support Scala `3.0.0-M2` (#24)
* Support Scala `3.0.0-M3` (#29)
