### PR TITLE
just-sysprocess v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,4 @@
+## [0.6.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2021-04-01
+
+## Done
+* Support Scala `3.0.0-RC2` (#39)


### PR DESCRIPTION
# just-sysprocess v0.6.0
## [0.6.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2021-04-01

## Done
* Support Scala `3.0.0-RC2` (#39)
