### PR TITLE
just-sysprocess v0.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           - { name: 'Scala 2', version: "2.13.5",    binary-version: "2.13",      java-version: "adopt@1.11" }
           - { name: 'Scala 3', version: "3.0.0-RC1", binary-version: "3.0.0-RC1", java-version: "adopt@1.11" }
           - { name: 'Scala 3', version: "3.0.0-RC2", binary-version: "3.0.0-RC2", java-version: "adopt@1.11" }
+          - { name: 'Scala 3', version: "3.0.0-RC3", binary-version: "3.0.0-RC3", java-version: "adopt@1.11" }
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,4 @@
+## [0.7.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-05-06
+
+## Done
+* Support Scala `3.0.0-RC3` (#45)


### PR DESCRIPTION
# just-sysprocess v0.7.0
## [0.7.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-05-06

## Done
* Support Scala `3.0.0-RC3` (#45)
