### PR TITLE
just-sysprocess v0.8.0

### DIFF
--- a/changelogs/0.8.0.md
+++ b/changelogs/0.8.0.md
@@ -1,0 +1,4 @@
+## [0.8.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2021-05-15
+
+## Done
+* Support Scala `3.0.0` (#50)


### PR DESCRIPTION
# just-sysprocess v0.8.0
## [0.8.0](https://github.com/Kevin-Lee/just-sysprocess/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2021-05-15

## Done
* Support Scala `3.0.0` (#50)
