### PR TITLE
Upgrade: sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ logLevel := sbt.Level.Warn
 
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.8.1")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.10.0")
 
-val sbtDevOopsVersion = "2.16.0"
+val sbtDevOopsVersion = "2.19.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
## Upgrade: sbt plugins
- sbt-devoops `2.16.0` => `2.19.0`
- sbt-docusaur `0.8.1` => `0.10.0`
