### PR TITLE
Bump sbt-ci-release to 1.9.3, sbt-docusaur to 0.17.0, and sbt-devoops to 3.2.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.9.3")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.16.0")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.17.0")
 
-val sbtDevOopsVersion = "3.1.0"
+val sbtDevOopsVersion = "3.2.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
Bump sbt-ci-release to 1.9.3, sbt-docusaur to 0.17.0, and sbt-devoops to 3.2.0