### PR TITLE
Update `.gitignore` to include `.bloop/` and all `metals.sbt` files in `project` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,10 @@ local.properties
 # Locally stored "Eclipse launch configurations"
 *.launch
 
-# sbt
+# sbt and build tool
 .bsp/
+.bloop/
+project/**/metals.sbt
 
 # sbteclipse plugin
 .target


### PR DESCRIPTION
# Summary
Update `.gitignore` to include `.bloop/` and all `metals.sbt` files in `project` directories